### PR TITLE
Some typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ We collected information on our main design goals:
 
 ## Overview of component libraries
 
-- [Material Design component library](materialdesign%20components/../materialdesign%20components/intro.md) - built by [Luise Freese](https://tiwtter.com/LuiseFreese) | @LuiseFreese and [Robin Rosengrün](https://twitter.com/power_r2) |@power_r2
+- [Material Design component library](materialdesign%20components/../materialdesign%20components/intro.md) - built by [Luise Freese]([https://tiwtter.com/LuiseFreese](https://twitter.com/LuiseFreese)) | @LuiseFreese and [Robin Rosengrün](https://twitter.com/power_r2) |@power_r2
   - [AppBar](materialdesign%20components/docs/AppBarTop.md)
   - [Banner](materialdesign%20components/docs/Banner.md)
   - [Bottom Navigation](materialdesign%20components/docs/BottomNavigation.md)
   - [Button](materialdesign%20components/docs/Button.md)
-  - [Checkbox]((materialdesign%20components/docsCheckbox.md))
+  - [Checkbox](materialdesign%20components/docsCheckbox.md)
   - [Contrast Checker](materialdesign%20components/docs/ContrastChecker.md)
   - [Dialog](materialdesign%20components/docs/Dialog.md)
-  - [Generic Input Frame](materialdesign%20components/docs/GerenericInputFrame.md)
+  - [Generic Input Frame](materialdesign%20components/docs/GenericInputFrame.md)
   - [Navigation Drawer](materialdesign%20components/docs/NavigationDrawer.md)
   - [Progress Indicator](materialdesign%20components/docs/ProgressIndicator.md)
   - [Side Sheet](materialdesign%20components/docs/SideSheet.md)
   - [Slider](materialdesign%20components/docs/Slider.md)
   - [Snackbar](materialdesign%20components/docs/Snackbar.md)
-  - [TextInput](materialdesign%20components/docs/Textinput.md)
+  - [TextInput](materialdesign%20components/docs/TextInput.md)
   - [Toggle](materialdesign%20components/docs/Toggle.md)
   
   - More component libraries to come!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We collected information on our main design goals:
 
 ## Overview of component libraries
 
-- [Material Design component library](materialdesign%20components/../materialdesign%20components/intro.md) - built by [Luise Freese]([https://tiwtter.com/LuiseFreese](https://twitter.com/LuiseFreese)) | @LuiseFreese and [Robin Rosengrün](https://twitter.com/power_r2) |@power_r2
+- [Material Design component library](materialdesign%20components/../materialdesign%20components/intro.md) - built by [Luise Freese](https://twitter.com/LuiseFreese) | @LuiseFreese and [Robin Rosengrün](https://twitter.com/power_r2) |@power_r2
   - [AppBar](materialdesign%20components/docs/AppBarTop.md)
   - [Banner](materialdesign%20components/docs/Banner.md)
   - [Bottom Navigation](materialdesign%20components/docs/BottomNavigation.md)


### PR DESCRIPTION
The link to Luise Freese Twitter account is incorrect,  https://tiwtter.com/LuiseFreese > https://twitter.com/luisefreese. The Markdown definition for the Checkbox link has double parents. The link to the GenericInputFrame was incorrect. The  Markdown filename is wrong GerenericInputFrame.md > GenericInputFrame.md. The link to the TextInput was incorrect. The Markdown filename is wrong Textinput.md > TextInput.md.